### PR TITLE
Updated README.md to correct git repo url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and install beans there.
     cd ~
     mkdir source
     cd source
-    git clone --recursive https://github.com/system76/beans.git
+    git clone --recursive https://github.com/system76/beansbooks.git
 
 You'll need to update the permissions on two directories before proceeding.
 ** TODO ** Talk about www-data


### PR DESCRIPTION
Tried to clone your repo, but received an error saying that info/refs could not be found. Noticed that the url for the git repo in the README.md was different from the one in github so I figured that was meant to be changed.
