### PR TITLE
Allow up to 3 decimals in quantity for Expenses, Orders, Sales and Invo…

### DIFF
--- a/application/classes/beans/customer.php
+++ b/application/classes/beans/customer.php
@@ -531,7 +531,7 @@ class Beans_Customer extends Beans {
 	@attribute tax_exempt BOOLEAN Whether or not this particular line is tax exempt.
 	@attribute description STRING
 	@attribute amount DECIMAL
-	@attribute quantity INTEGER
+	@attribute quantity DECIMAL
 	@attribute total DECIMAL
 	---BEANSENDSPEC---
 	 */

--- a/application/classes/beans/customer/sale/create.php
+++ b/application/classes/beans/customer/sale/create.php
@@ -41,7 +41,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the sale.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the sale towards ( in terms of revenue ).
 @optional @attribute lines tax_exempt BOOLEAN
 @optional taxes ARRAY An array of objects representing taxes applicable to the sale.
@@ -248,7 +248,7 @@ class Beans_Customer_Sale_Create extends Beans_Customer_Sale {
 								   : NULL;
 
 			$new_sale_line->quantity = ( isset($sale_line->quantity) )
-									 ? (int)$sale_line->quantity
+									 ? (float)$sale_line->quantity
 									 : NULL;
 
 			// Handle Default Income Account

--- a/application/classes/beans/customer/sale/create.php
+++ b/application/classes/beans/customer/sale/create.php
@@ -41,7 +41,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the sale.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the sale towards ( in terms of revenue ).
 @optional @attribute lines tax_exempt BOOLEAN
 @optional taxes ARRAY An array of objects representing taxes applicable to the sale.

--- a/application/classes/beans/customer/sale/update.php
+++ b/application/classes/beans/customer/sale/update.php
@@ -41,7 +41,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the sale.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the sale towards ( in terms of revenue ).
 @optional @attribute lines tax_exempt BOOLEAN
 @optional taxes ARRAY An array of objects representing taxes applicable to the sale.
@@ -223,7 +223,7 @@ class Beans_Customer_Sale_Update extends Beans_Customer_Sale {
 									  : NULL;
 
 			$new_sale_line->quantity = ( isset($sale_line->quantity) )
-										? (int)$sale_line->quantity
+										? (float)$sale_line->quantity
 										: NULL;
 
 			// Handle Default Income Account

--- a/application/classes/beans/customer/sale/update.php
+++ b/application/classes/beans/customer/sale/update.php
@@ -41,7 +41,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the sale.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the sale towards ( in terms of revenue ).
 @optional @attribute lines tax_exempt BOOLEAN
 @optional taxes ARRAY An array of objects representing taxes applicable to the sale.

--- a/application/classes/beans/setup/update/v/1/4/1.php
+++ b/application/classes/beans/setup/update/v/1/4/1.php
@@ -26,7 +26,7 @@ class Beans_Setup_Update_V_1_4_1 extends Beans_Setup_Update_V {
 	
 	protected function _execute()
 	{
-		$this->_db_update_table_column(	'form_lines', 'quantity', 'decimal( 6, 2 ) DEFAULT NULL');
+		$this->_db_update_table_column(	'form_lines', 'quantity', 'decimal( 13, 3 ) DEFAULT NULL');
 		
 		return (object)array();
 	}

--- a/application/classes/beans/setup/update/v/1/4/1.php
+++ b/application/classes/beans/setup/update/v/1/4/1.php
@@ -26,7 +26,7 @@ class Beans_Setup_Update_V_1_4_1 extends Beans_Setup_Update_V {
 	
 	protected function _execute()
 	{
-		$this->_db_update_table_column(	'form_lines', 'quantity', 'decimal( 13, 3 ) DEFAULT NULL');
+		$this->_db_update_table_column( 'form_lines', 'quantity', '`quantity` decimal( 13, 3 ) NULL DEFAULT NULL');
 		
 		return (object)array();
 	}

--- a/application/classes/beans/setup/update/v/1/4/1.php
+++ b/application/classes/beans/setup/update/v/1/4/1.php
@@ -1,0 +1,35 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/*
+BeansBooks
+Copyright (C) System76, Inc.
+
+This file is part of BeansBooks.
+
+BeansBooks is free software; you can redistribute it and/or modify
+it under the terms of the BeansBooks Public License.
+
+BeansBooks is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+See the BeansBooks Public License for more details.
+
+You should have received a copy of the BeansBooks Public License
+along with BeansBooks; if not, email info@beansbooks.com.	
+*/
+
+class Beans_Setup_Update_V_1_4_1 extends Beans_Setup_Update_V {
+
+	public function __construct($data = NULL)
+	{
+		parent::__construct($data);
+	}
+	
+	protected function _execute()
+	{
+		$this->_db_update_table_column(	'form_lines', 'quantity', 'decimal( 6, 2 ) DEFAULT NULL');
+		
+		return (object)array();
+	}
+
+
+}

--- a/application/classes/beans/vendor.php
+++ b/application/classes/beans/vendor.php
@@ -1041,7 +1041,7 @@ class Beans_Vendor extends Beans {
 	@attribute account OBJECT The #Beans_Account# to categorize the cost.
 	@attribute description STRING 
 	@attribute amount DECIMAL
-	@attribute quantity DECIMAL Must be >= 0
+	@attribute quantity DECIMAL (up to three decimal places).
 	@attribute total DECIMAL The total from the amount and quantity.
 	---BEANSENDSPEC---
 	 */
@@ -1054,7 +1054,7 @@ class Beans_Vendor extends Beans {
 	@attribute account OBJECT The #Beans_Account# to categorize the cost.
 	@attribute description STRING 
 	@attribute amount DECIMAL
-	@attribute quantity DECIMAL Must be >= 0
+	@attribute quantity DECIMAL (up to three decimal places).
 	@attribute total DECIMAL The total from the amount and quantity.
 	---BEANSENDSPEC---
 	 */

--- a/application/classes/beans/vendor.php
+++ b/application/classes/beans/vendor.php
@@ -1041,7 +1041,7 @@ class Beans_Vendor extends Beans {
 	@attribute account OBJECT The #Beans_Account# to categorize the cost.
 	@attribute description STRING 
 	@attribute amount DECIMAL
-	@attribute quantity INTEGER Must be >= 0
+	@attribute quantity DECIMAL Must be >= 0
 	@attribute total DECIMAL The total from the amount and quantity.
 	---BEANSENDSPEC---
 	 */
@@ -1054,7 +1054,7 @@ class Beans_Vendor extends Beans {
 	@attribute account OBJECT The #Beans_Account# to categorize the cost.
 	@attribute description STRING 
 	@attribute amount DECIMAL
-	@attribute quantity INTEGER Must be >= 0
+	@attribute quantity DECIMAL Must be >= 0
 	@attribute total DECIMAL The total from the amount and quantity.
 	---BEANSENDSPEC---
 	 */

--- a/application/classes/beans/vendor/expense/create.php
+++ b/application/classes/beans/vendor/expense/create.php
@@ -34,7 +34,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the expense.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the expense towards.
 @returns expense OBJECT The resulting #Beans_Vendor_Expense#.
 ---BEANSENDSPEC---
@@ -134,7 +134,7 @@ class Beans_Vendor_Expense_Create extends Beans_Vendor_Expense {
 									  : NULL;
 
 			$new_expense_line->quantity = ( isset($expense_line->quantity) )
-										? (int)$expense_line->quantity
+										? (float)$expense_line->quantity
 										: NULL;
 
 			$this->_validate_form_line($new_expense_line);

--- a/application/classes/beans/vendor/expense/create.php
+++ b/application/classes/beans/vendor/expense/create.php
@@ -34,7 +34,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the expense.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the expense towards.
 @returns expense OBJECT The resulting #Beans_Vendor_Expense#.
 ---BEANSENDSPEC---

--- a/application/classes/beans/vendor/expense/update.php
+++ b/application/classes/beans/vendor/expense/update.php
@@ -34,7 +34,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the expense.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the expense towards.
 @returns expense OBJECT The resulting #Beans_Vendor_Expense#.
 ---BEANSENDSPEC---

--- a/application/classes/beans/vendor/expense/update.php
+++ b/application/classes/beans/vendor/expense/update.php
@@ -34,7 +34,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the expense.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the expense towards.
 @returns expense OBJECT The resulting #Beans_Vendor_Expense#.
 ---BEANSENDSPEC---
@@ -148,7 +148,7 @@ class Beans_Vendor_Expense_Update extends Beans_Vendor_Expense {
 									  : NULL;
 
 			$new_expense_line->quantity = ( isset($expense_line->quantity) )
-										? (int)$expense_line->quantity
+										? (float)$expense_line->quantity
 										: NULL;
 
 			$this->_validate_form_line($new_expense_line);

--- a/application/classes/beans/vendor/purchase/create.php
+++ b/application/classes/beans/vendor/purchase/create.php
@@ -37,7 +37,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the purchase.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the purchase towards.
 @returns purchase OBJECT The resulting #Beans_Vendor_Purchase#.
 ---BEANSENDSPEC---
@@ -194,7 +194,7 @@ class Beans_Vendor_Purchase_Create extends Beans_Vendor_Purchase {
 									  : NULL;
 
 			$new_purchase_line->quantity = ( isset($purchase_line->quantity) )
-										? (int)$purchase_line->quantity
+										? (float)$purchase_line->quantity
 										: NULL;
 
 			// Handle Default Cost of Goods

--- a/application/classes/beans/vendor/purchase/create.php
+++ b/application/classes/beans/vendor/purchase/create.php
@@ -37,7 +37,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the purchase.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the purchase towards.
 @returns purchase OBJECT The resulting #Beans_Vendor_Purchase#.
 ---BEANSENDSPEC---

--- a/application/classes/beans/vendor/purchase/update.php
+++ b/application/classes/beans/vendor/purchase/update.php
@@ -37,7 +37,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the purchase.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity DECIMAL The number of units.
+@required @attribute lines quantity DECIMAL The number of units (up to three decimal places).
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the purchase towards.
 @returns purchase OBJECT The resulting #Beans_Vendor_Purchase#.
 ---BEANSENDSPEC---

--- a/application/classes/beans/vendor/purchase/update.php
+++ b/application/classes/beans/vendor/purchase/update.php
@@ -37,7 +37,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 @required lines ARRAY An array of objects representing line items for the purchase.
 @required @attribute lines description STRING The text for the line item.
 @required @attribute lines amount DECIMAL The amount per unit.
-@required @attribute lines quantity INTEGER The number of units.
+@required @attribute lines quantity DECIMAL The number of units.
 @optional @attribute lines account_id INTEGER The ID of the #Beans_Account# to count the cost of the purchase towards.
 @returns purchase OBJECT The resulting #Beans_Vendor_Purchase#.
 ---BEANSENDSPEC---
@@ -215,7 +215,7 @@ class Beans_Vendor_Purchase_Update extends Beans_Vendor_Purchase {
 									  : NULL;
 
 			$new_purchase_line->quantity = ( isset($purchase_line->quantity) )
-										? (int)$purchase_line->quantity
+										? (float)$purchase_line->quantity
 										: NULL;
 
 			$new_purchase_line->adjustment = ( isset($purchase_line->adjustment) )

--- a/application/templates/vendors/expenses.mustache
+++ b/application/templates/vendors/expenses.mustache
@@ -52,9 +52,9 @@
 		</div>
 
 		<div class="row column-10 labels">
-			<span class="elevator-dance">Description</span>
+			<span class="subway-dance">Description</span>
 			<span class="ehhh-sexy-lady">Expense Account</span>
-			<span class="oop">QTY</span>
+			<span class="oop-oop">QTY</span>
 			<span class="oop-oop">Price</span>
 			<span class="oop-oop">Total</span>
 		</div>
@@ -146,7 +146,7 @@
 
 <div id="vendors-expenses-create-form-lines-line-template" class="hidden">
 	<div class="vendors-expenses-create-form-lines-line row column-10">
-		<span class="elevator-dance"><input type="text" class="line-description" name="line-description"></span>
+		<span class="subway-dance"><input type="text" class="line-description" name="line-description"></span>
 		<span class="ehhh-sexy-lady"><select name="line-account_id" class="account_id">
 			<option value="">&nbsp;</option>
 			{{#all_accounts_chart_flat}}
@@ -157,7 +157,7 @@
 				{{/reserved}}
 			{{/all_accounts_chart_flat}}
 		</select></span>
-		<span class="oop"><input type="text" class="line-quantity" name="line-quantity" val="0"></span>
+		<span class="oop-oop"><input type="text" class="line-quantity" name="line-quantity" val="0"></span>
 		<span class="oop-oop"><input type="text" class="line-price" name="line-price" val="0.00"></span>
 		<span class="oop-oop"><input type="text" class="line-total" name="line-total" readonly="readonly" value="0.00"></span>
 		<input type="hidden" name="expense-line-key" value="EXPENSELINEKEY">

--- a/application/templates/vendors/purchases.mustache
+++ b/application/templates/vendors/purchases.mustache
@@ -83,9 +83,9 @@
 		</div>
 
 		<div class="row column-10 labels">
-			<span class="elevator-dance">Description</span>
+			<span class="subway-dance">Description</span>
 			<span class="ehhh-sexy-lady">Expense Account</span>
-			<span class="oop">QTY</span>
+			<span class="oop-oop">QTY</span>
 			<span class="oop-oop">Price</span>
 			<span class="oop-oop">Total</span>
 		</div>
@@ -203,7 +203,7 @@
 
 <div id="vendors-purchases-create-form-lines-line-template" class="hidden">
 	<div class="vendors-purchases-create-form-lines-line row column-10">
-		<span class="elevator-dance"><input type="text" class="line-description" name="line-description"></span>
+		<span class="subway-dance"><input type="text" class="line-description" name="line-description"></span>
 		<span class="ehhh-sexy-lady"><select name="line-account_id" class="account_id">
 			<option value="">&nbsp;</option>
 			{{#all_accounts_chart_flat}}
@@ -220,7 +220,7 @@
 				{{/reserved}}
 			{{/all_accounts_chart_flat}}
 		</select></span>
-		<span class="oop"><input type="text" class="line-quantity" name="line-quantity" val="0"></span>
+		<span class="oop-oop"><input type="text" class="line-quantity" name="line-quantity" val="0"></span>
 		<span class="oop-oop"><input type="text" class="line-price" name="line-price" val="0.00"></span>
 		<span class="oop-oop"><input type="text" class="line-total" name="line-total" readonly="readonly" value="0.00"></span>
 		<input type="hidden" name="purchase-line-key" value="PURCHASELINEKEY">

--- a/static/css/form.css
+++ b/static/css/form.css
@@ -210,6 +210,10 @@ along with BeansBooks; if not, email info@beansbooks.com.
 	width: 312px;
 }
 
+.form .row.column-10 > span.subway-dance {
+	width: 400px;	
+}
+
 .form .row.column-10 > span.elevator-dance {
 	width: 450px;	
 }

--- a/static/css/form.css
+++ b/static/css/form.css
@@ -211,7 +211,7 @@ along with BeansBooks; if not, email info@beansbooks.com.
 }
 
 .form .row.column-10 > span.subway-dance {
-	width: 400px;	
+	width: 404px;
 }
 
 .form .row.column-10 > span.elevator-dance {

--- a/static/js/customers.js
+++ b/static/js/customers.js
@@ -2352,7 +2352,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)customers(\\s|$)')) !== nu
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(parseInt($quantity.val()));
+				$quantity.val(Math.round($quantity.val()*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&
@@ -2366,7 +2366,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)customers(\\s|$)')) !== nu
 					$quantity.val( $quantity.val() * -1 );
 				}
 
-				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseInt($quantity.val()))).toFixed(2));
+				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseFloat($quantity.val()))).toFixed(2));
 
 				if( ! formTaxExempt && 
 					! lineTaxExempt ) {

--- a/static/js/customers.js
+++ b/static/js/customers.js
@@ -2352,7 +2352,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)customers(\\s|$)')) !== nu
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(Math.round($quantity.val()*1000) / 1000);
+				$quantity.val(Math.round(parseFloat($quantity.val())*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&

--- a/static/js/vendors.js
+++ b/static/js/vendors.js
@@ -4028,7 +4028,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(parseInt($quantity.val()));
+				$quantity.val(Math.round($quantity.val()*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&
@@ -4042,7 +4042,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 					$quantity.val( $quantity.val() * -1 );
 				}
 
-				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseInt($quantity.val()))).toFixed(2));
+				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseFloat($quantity.val()))).toFixed(2));
 				
 				total = parseFloat(parseFloat(total) + parseFloat($total.val())).toFixed(2);
 			} else {
@@ -4360,7 +4360,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(parseInt($quantity.val()));
+				$quantity.val(Math.round($quantity.val()*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&
@@ -4374,7 +4374,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 					$quantity.val( $quantity.val() * -1 );
 				}
 
-				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseInt($quantity.val()))).toFixed(2));
+				$total.val(parseFloat(monetaryRound(parseFloat($price.val()) * parseFloat($quantity.val()))).toFixed(2));
 				
 				total = parseFloat(parseFloat(total) + parseFloat($total.val())).toFixed(2);
 			} else {

--- a/static/js/vendors.js
+++ b/static/js/vendors.js
@@ -4028,7 +4028,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(Math.round($quantity.val()*1000) / 1000);
+				$quantity.val(Math.round(parseFloat($quantity.val())*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&
@@ -4360,7 +4360,7 @@ if ( document.body.className.match(new RegExp('(\\s|^)vendors(\\s|$)')) !== null
 
 			if( $quantity.val() &&
 				$quantity.val().length ) {
-				$quantity.val(Math.round($quantity.val()*1000) / 1000);
+				$quantity.val(Math.round(parseFloat($quantity.val())*1000) / 1000);
 			}
 			
 			if( $quantity.val() &&


### PR DESCRIPTION
This is a first attempt and I'm very new. I tried to make sure I got all the changes from #120, but there are a few things I can't test:

1. The database modifications in application/classes/beans/setup/update/v/1/4/1.php (because I just made the change myself without applying it as a patch), and...
2. The validation code in application/classes/beans/customer.php (because I don't totally understand when this is supposed to be used since the Javascript manages the decimal places.)
3. I don't even completely understand what these do, but I figured out they needed to be changed and what to change:
  * /application/classes/beans/vendor/expense/create.php and update.php
  * /application/classes/beans/vendor/purchase/create.php and update.php
  * /application/classes/beans/customer/sale/create.php and update.php

As for my testing, this seems to work for Customers > Sales Orders, Customers > Invoices, Vendors > Expenses, Vendors > Purchase Orders.

This is an attempt to complete issue #120.